### PR TITLE
fix sendCommand responses

### DIFF
--- a/src/classes/RCEManager.ts
+++ b/src/classes/RCEManager.ts
@@ -743,9 +743,11 @@ export default class RCEManager extends RCEEvents {
 
         this.commands = this.commands.filter(
           (req) =>
-            req.command !== commandRequest.command &&
-            req.identifier !== commandRequest.identifier &&
-            req.timestamp !== commandRequest.timestamp
+          !(
+            req.command === commandRequest.command &&
+            req.identifier === commandRequest.identifier &&
+            req.timestamp === commandRequest.timestamp
+          )
         );
       }
 


### PR DESCRIPTION
The filter being used after responding to a command was removing all commands that had same `command`, `identifier`, or `timestamp` property as commandRequest.