### PR TITLE
Add support for player ban/unban and server saving events

### DIFF
--- a/src/data/playerKill.ts
+++ b/src/data/playerKill.ts
@@ -373,6 +373,31 @@ export const playerKillData = [
     name: "Submarine",
     type: PlayerKillType.Entity,
   },
+  {
+    id: "submarineduo.entity (entity)",
+    name: "Submarine",
+    type: PlayerKillType.Entity,
+  },
+  {
+    id: "gates.external.high.adobe (entity)",
+    name: "High External Adobe Gate",
+    type: PlayerKillType.Entity,
+  },
+  {
+    id: "graveyardfence (entity)",
+    name: "Graveyard Fence",
+    type: PlayerKillType.Entity,
+  },
+  {
+    id: "fireball_small (entity)",
+    name: "Fireball",
+    type: PlayerKillType.Entity,
+  },
+  {
+    id: "fireball_small (entity)",
+    name: "Fireball",
+    type: PlayerKillType.Entity,
+  },
 ];
 
 export function getKill(ign: string): IKillPlayer {

--- a/src/data/quickChat.ts
+++ b/src/data/quickChat.ts
@@ -72,3 +72,8 @@ export enum QuickChat {
   HAVE_Hatchet = "d11_quick_chat_i_have_phrase_format hatchet",
   HAVE_HighQualityMetal = "d11_quick_chat_i_have_phrase_format metal.refined",
 }
+export enum QuickChatChannel {
+  TEAM = "TEAM",
+  SERVER = "SERVER",
+  LOCAL = "LOCAL",
+}

--- a/src/data/regularExpressions.ts
+++ b/src/data/regularExpressions.ts
@@ -12,6 +12,10 @@ export const RegularExpressions: { [key: string]: RegExp } = {
   PlayerRoleRemove: new RegExp(
     /\[([\w\s-]+)] Removed \[([\w\s-]+)] from Group \[([\w\s-]+)]/
   ),
+  PlayerBanned: new RegExp(/\[([\w\s-]+)\] Added \[([\w\s-]+)\] to \[Banned\]/),
+  PlayerUnbanned: new RegExp(
+    /\[([\w\s-]+)\] Removed \[([\w\s-]+)\] from \[Banned\]/
+  ),
   ItemSpawn: new RegExp(
     /\bgiving ([\w\s._-]+) ([\d.]+) x ([\w\s._-]+(?: [\w\s._-]+)*)\b/
   ),
@@ -38,4 +42,5 @@ export const RegularExpressions: { [key: string]: RegExp } = {
   KitGive: new RegExp(
     /\[ServerVar\] ([\w\s_-]+) giving ([\w\s_-]+) kit ([\w\s_-]+)/
   ),
+  ServerSaving: new RegExp(/^\[ SAVE \] Saved (\d+) ents$/),
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { WebSocket } from "ws";
 import { type PlayerKillType } from "./data/playerKill";
-import { QuickChat } from "./data/quickChat";
+import { QuickChat, QuickChatChannel } from "./data/quickChat";
 
 export interface IOptions {
   logger: {
@@ -84,7 +84,7 @@ export interface IVendingMachineNameEventPayload extends EventPayload {
 }
 
 export interface IQuickChatEventPayload extends EventPayload {
-  type: "team" | "server" | "local";
+  type: QuickChatChannel;
   ign: string;
   message: QuickChat;
 }
@@ -95,7 +95,7 @@ export interface IPlayerSuicideEventPayload extends EventPayload {
 
 export interface IPlayerRespawnedEventPayload extends EventPayload {
   ign: string;
-  platform: "PS" | "XBL";
+  platform: GamePlatform;
 }
 
 export interface ICustomZoneCreatedEventPayload extends EventPayload {
@@ -116,6 +116,15 @@ export interface IPlayerRoleRemoveEventPayload extends EventPayload {
   admin?: string;
   ign: string;
   role: string;
+}
+
+export interface IPlayerBannedEventPayload extends EventPayload {
+  admin?: string;
+  ign: string;
+}
+export interface IPlayerUnbannedEventPayload extends EventPayload {
+  admin?: string;
+  ign: string;
 }
 
 export interface IIitemSpawnEventPayload extends EventPayload {
@@ -215,6 +224,11 @@ export interface IFrequencyLostEventPayload extends EventPayload {
   frequency: number;
 }
 
+export interface IServerSavingEventPayload extends EventPayload {
+  server?: IServer;
+  entities: number;
+}
+
 export interface IErrorEventPayload {
   server?: IServer;
   error: string;
@@ -238,6 +252,8 @@ export enum RCEEvent {
   CustomZoneRemoved = "customZoneRemoved",
   PlayerRoleAdd = "playerRoleAdd",
   PlayerRoleRemove = "playerRoleRemove",
+  PlayerBanned = "playerBanned",
+  PlayerUnbanned = "playerUnbanned",
   ItemSpawn = "itemSpawn",
   NoteEdit = "noteEdit",
   TeamCreated = "teamCreated",
@@ -254,6 +270,7 @@ export enum RCEEvent {
   PlayerListUpdated = "playerListUpdated",
   FrequencyGained = "frequencyGained",
   FrequencyLost = "frequencyLost",
+  ServerSaving = "serverSaving",
   Error = "error",
 }
 
@@ -269,6 +286,8 @@ export interface IEvent {
   [RCEEvent.CustomZoneRemoved]: ICustomZoneRemovedEventPayload;
   [RCEEvent.PlayerRoleAdd]: IPlayerRoleAddEventPayload;
   [RCEEvent.PlayerRoleRemove]: IPlayerRoleRemoveEventPayload;
+  [RCEEvent.PlayerBanned]: IPlayerBannedEventPayload;
+  [RCEEvent.PlayerUnbanned]: IPlayerUnbannedEventPayload;
   [RCEEvent.ItemSpawn]: IIitemSpawnEventPayload;
   [RCEEvent.NoteEdit]: INoteEditEventPayload;
   [RCEEvent.TeamCreated]: ITeamCreatedEventPayload;
@@ -285,7 +304,13 @@ export interface IEvent {
   [RCEEvent.PlayerListUpdated]: IPlayerListUpdatedEventPayload;
   [RCEEvent.FrequencyGained]: IFrequencyGainedEventPayload;
   [RCEEvent.FrequencyLost]: IFrequencyLostEventPayload;
+  [RCEEvent.ServerSaving]: IServerSavingEventPayload;
   [RCEEvent.Error]: IErrorEventPayload;
+}
+
+export enum GamePlatform {
+  Playstation = "PS",
+  XBOX = "XBL",
 }
 
 /*


### PR DESCRIPTION
Introduces new event handling for player ban and unban actions, as well as server saving notifications. Adds corresponding regular expressions, event payload interfaces, and event types. Refactors quick chat channel and platform handling to use enums for improved type safety. Updates player kill data with additional entities.