### PR TITLE
Track player online status and last seen time

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export interface IServer {
   flags: string[];
   intervals: IServerIntervals;
   state: any[];
-  players: Player[];
+  players: Player[]; // All players with isOnline flag
   frequencies: number[];
   teams: Team[];
 }
@@ -284,6 +284,8 @@ export interface Player {
   health: number;
   team?: Team | null;
   platform?: GamePlatform;
+  isOnline: boolean;
+  lastSeen?: Date;
 }
 
 export interface Team {


### PR DESCRIPTION
Adds isOnline and lastSeen fields to Player objects and updates logic to track player connection status. getOrCreatePlayer now accepts a markAsOnline flag and emits PlayerJoined events when appropriate. Manager now provides getOnlinePlayers and getOfflinePlayers methods, and updatePlayers marks players as offline instead of removing them from the list.