### PR TITLE
Track player online status and last seen time

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export interface IServer {
   frequencies: number[];
   teams: ITeam[];
   info?: IRustServerInformation;
+  getOnlinePlayers(): IPlayer[];
+  getOfflinePlayers(): IPlayer[];
 }
 
 export interface IRustServerInformation {
@@ -292,6 +294,8 @@ export interface IPlayer {
   platform?: GamePlatform;
   role?: GameRole;
   state: any[];
+  isOnline: boolean;
+  lastSeen?: Date;
 }
 
 export interface ITeam {


### PR DESCRIPTION
Adds isOnline and lastSeen fields to IPlayer and methods to IServer for retrieving online/offline players. Updates player management logic to mark players as online/offline based on events and player list updates, and emits PlayerJoined events when appropriate.